### PR TITLE
exit on Ctrl+D, like bash

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,8 @@ fn main() {
                 history::add(&mut sh, &mut rl, &line, status, tsb, tse);
             }
             Ok(ReadResult::Eof) => {
-                println!("");
-                continue;
+                println!("exit");
+                break;
             }
             Ok(ReadResult::Signal(s)) => {
                 println!("readline signal: {:?}", s);


### PR DESCRIPTION
this was the very first thing that I missed while trying `cicada`

