### PR TITLE
implement 'source' builtin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Made brace expansion behavior align with bash.
 - Fixed an issue of path completion in middle of input.
+- Implemented builtin command `source`
 
 ## 0.9.2
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -8,3 +8,4 @@ pub mod fg;
 pub mod history;
 pub mod jobs;
 pub mod vox;
+pub mod source;

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -16,6 +16,9 @@ pub fn run(sh: &mut shell::Shell, tokens: &Tokens) -> i32 {
         println_stderr!("cicada: source: no file specified");
         return 1;
     }
+    if !args[1].ends_with("cicadarc") {
+        println_stderr!("cicada: source command only supports cicadarc files");
+    }
 
     rcfile::load_file(sh, &args[1], 1);
     0

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -18,6 +18,7 @@ pub fn run(sh: &mut shell::Shell, tokens: &Tokens) -> i32 {
     }
     if !args[1].ends_with("cicadarc") {
         println_stderr!("cicada: source command only supports cicadarc files");
+        println_stderr!("scripting in cicada is still a work in progress");
     }
 
     rcfile::load_file(sh, &args[1], 1);

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -1,0 +1,22 @@
+use std::io::Write;
+
+use crate::shell;
+use crate::parsers;
+use crate::rcfile;
+use crate::types::Tokens;
+
+
+pub fn run(sh: &mut shell::Shell, tokens: &Tokens) -> i32 {
+    let args = parsers::parser_line::tokens_to_args(&tokens);
+    if args.len() > 2 {
+        println_stderr!("cicada: source: too many arguments");
+        return 1;
+    }
+    if args.len() < 2 {
+        println_stderr!("cicada: source: no file specified");
+        return 1;
+    }
+
+    rcfile::load_file(sh, &args[1], 1);
+    0
+}

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -19,6 +19,7 @@ pub fn run(sh: &mut shell::Shell, tokens: &Tokens) -> i32 {
     if !args[1].ends_with("cicadarc") {
         println_stderr!("cicada: source command only supports cicadarc files");
         println_stderr!("scripting in cicada is still a work in progress");
+        return 1;
     }
 
     rcfile::load_file(sh, &args[1], 1);

--- a/src/completers/path.rs
+++ b/src/completers/path.rs
@@ -165,7 +165,7 @@ fn complete_bin(sh: &shell::Shell, path: &str) -> Vec<Completion> {
         });
     }
     let builtins = vec![
-        "cd", "cinfo", "exec", "exit", "export", "fg", "history", "jobs", "fg", "vox",
+        "cd", "cinfo", "exec", "exit", "export", "fg", "history", "jobs", "fg", "vox", "source"
     ];
     for item in &builtins {
         if !item.starts_with(fname) {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -191,6 +191,9 @@ pub fn run_proc(sh: &mut shell::Shell, line: &str, tty: bool) -> i32 {
     if cmd == "vox" && tokens.len() > 1 && (tokens[1].1 == "enter" || tokens[1].1 == "exit") {
         return builtins::vox::run(sh, &tokens);
     }
+    if cmd == "source" {
+        return builtins::source::run(sh, &tokens);
+    }
 
     // for any other situations
     let mut background = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod jobc;
 mod libs;
 mod parsers;
 mod shell;
+mod rcfile;
 
 /// Represents an error calling `exec`.
 pub use crate::types::CommandResult;

--- a/src/rcfile.rs
+++ b/src/rcfile.rs
@@ -10,7 +10,7 @@ use crate::shell;
 use crate::tools;
 use crate::types;
 
-fn load_file(sh: &mut shell::Shell, file_path: &str, count: i32) {
+pub fn load_file(sh: &mut shell::Shell, file_path: &str, count: i32) {
     if count > 99 {
         // to prevent dead include loop
         println_stderr!("loaded too many rc files");


### PR DESCRIPTION
Hey,

I noticed your shell does not have the `source` command as one of its builtins, which lets you source rc files during a session. It works like this: make a change to ~/.cicadarc, run `source ~/.cicadarc`, and any changes you made to your RC file will then be loaded. I was a pretty simple implementation, I just had to call the `load_file` function in the rcfile module. I hope you will incorporate this into your project.