### PR TITLE
Support running tests without bash and with release and refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,41 @@
-run:
-	@rustc -V
-	# cargo update
-	cargo build
-	./target/debug/cicada -l
+# Install to current root by default
+DESTDIR := ""
+# Install to homedir by default to avoid using root
+PREFIX := ${HOME}/.local
+# Debug is the default
+MODE := debug
 
-install:
-	# cargo update
-	cargo build --release
-	cp target/release/cicada /usr/local/bin/
+ifeq ($(MODE),debug)
+	MODEFLAG="--"
+else
+	MODEFLAG="--$(MODE)"
+endif
 
-doc:
-	cargo doc --open
+build:
+	cargo build "${MODEFLAG}"
 
-test:
-	@rustc -V
-	cargo test --bins
-
-scripting-test:
-	cargo build
-	./tests/test_scripts.sh 2>/dev/null
+clean:
+	cargo clean
+	find . -name '*.rs.bk' | xargs -0 rm -f
 
 clippy:
 	cargo clippy -- -A clippy::needless_return -A clippy::ptr_arg
 
-clean:
-	cargo clean
-	find . -name '*.rs.bk' | xargs rm -f
+doc:
+	cargo doc --open
+
+fmt:
+	cargo fmt
+
+install: build
+	install -Dm755 target/"${MODE}"/cicada "${DESTDIR}"/"${PREFIX}"/bin/cicada
+
+run: build
+	cargo run "${MODEFLAG}" -- -l
+
+test: build
+	cargo test --bins "${MODEFLAG}"
+	MODE="${MODE}" ./tests/test_scripts.sh 2>/dev/null
+
+
+.PHONY: build clean clippy doc fmt install run test

--- a/tests/scripts/regression-001.sh
+++ b/tests/scripts/regression-001.sh
@@ -45,9 +45,9 @@ ulimit -c
 ulimit | wc
 
 echo '--- for exit code ---'
-./target/debug/cicada -c cinfo1
+./"${CICADA}" -c cinfo1
 echo $?
 echo 'exit 3' > exit3.sh
-./target/debug/cicada exit3.sh
+./"${CICADA}" exit3.sh
 echo $?
 rm -f exit3.sh

--- a/tests/test_scripts.sh
+++ b/tests/test_scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 CICADA="./target/debug/cicada"
 

--- a/tests/test_scripts.sh
+++ b/tests/test_scripts.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-set -e
-CICADA="./target/debug/cicada"
 
-if [ ! -f $CICADA ]; then
+set -e
+
+CICADA="./target/${MODE}/cicada"
+
+if [ ! -f "$CICADA" ]; then
     echo "cicada binary not found: $CICADA"
     echo "please build it out with cargo build first"
     exit 1
@@ -11,10 +13,10 @@ fi
 DIR_TEST="$( cd "$(dirname "$0")" ; pwd -P )"
 TMP_FILE="${DIR_TEST}/tmpfile-test-cicada-scripts.out"
 
-for src in ${DIR_TEST}/scripts/*.sh; do
-    echo Runing $CICADA $src
-    $CICADA $src > "$TMP_FILE"
-    if diff -u "${src}.out" $TMP_FILE; then
+for src in "${DIR_TEST}"/scripts/*.sh; do
+    echo "Running $CICADA $src"
+    CICADA="$CICADA" "$CICADA" "$src" > "$TMP_FILE"
+    if diff -u "${src}.out" "$TMP_FILE"; then
         echo OK.
     else
         echo Failed.
@@ -22,4 +24,4 @@ for src in ${DIR_TEST}/scripts/*.sh; do
     fi
 done
 
-rm -f $TMP_FILE
+rm -f "$TMP_FILE"


### PR DESCRIPTION
This MR:
- Switches tests/test_scripting.sh to use sh instead of bash, along with making it pass shellcheck
- Supports using the release target for tests
- Cleans up the Makefile and adds some nice variables for usage with distro packaging.

I changed the default destdir to `~/.local/bin` since installing to `/usr/local/bin/` requires root on a lot of systems, so I thought the default install probably didn't need that. I also combined the `scripting-tests` and `test` targets into one so as to allow easier combined testing. Finally, the $MODEFLAG selection *does* use some gmake-specific logic to make it cleaner, so if this is not okay I can rework it to also work with bmake.